### PR TITLE
Use typetalk.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[Fluentd](http://fluentd.org) plugin to emit notifications to [Typetalk](http://typetalk.in/).
+[Fluentd](http://fluentd.org) plugin to emit notifications to [Typetalk](http://typetalk.com/).
 
 ## Requirements
 
@@ -27,7 +27,7 @@ $ sudo /usr/lib64/fluent/ruby/bin/fluent-gem install fluent-plugin-typetalk
 
 ### Usage
 
-This plugin uses client credentials for authentication. See [the developer document](http://developers.typetalk.in/oauth.html) how to get your own credential.
+This plugin uses client credentials for authentication. See [the developer document](https://developer.nulab-inc.com/docs/typetalk/#client) how to get your own credential.
 ```
 <match ...>
   type typetalk

--- a/fluent-plugin-typetalk.gemspec
+++ b/fluent-plugin-typetalk.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", ">= 1.0.5"
 
   spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
-  spec.add_runtime_dependency "typetalk"
+  spec.add_runtime_dependency "typetalk", ">= 0.0.6"
 end


### PR DESCRIPTION
fluent-plugin-typetalk depend on typetalk-rb module, that library supported to request API to typetalk.com domain.

https://github.com/umakoz/typetalk-rb/pull/7